### PR TITLE
fix(gotify): cache app tokens against Gotify 3.0 GET regression

### DIFF
--- a/terraform/gotify/applications.tofu
+++ b/terraform/gotify/applications.tofu
@@ -30,3 +30,22 @@ resource "gotify_application" "app" {
   name        = each.key
   description = each.key
 }
+
+# Gotify 3.0.0 stopped returning application tokens on GET; tokens are only
+# exposed on creation or rotation (PUT /application/{id}/security). The
+# gotify provider (0.3.0) still reads the token via GET on every refresh,
+# so gotify_application.app[*].token gets wiped to "" before each plan/apply.
+#
+# Cache the token once here, right after it's set at creation time, and
+# ignore all later changes so a refresh can't clobber the cached value.
+# secrets.tofu reads the token from this cache instead of directly from
+# gotify_application.
+resource "terraform_data" "app_token_cache" {
+  for_each = gotify_application.app
+
+  input = each.value.token
+
+  lifecycle {
+    ignore_changes = [input]
+  }
+}

--- a/terraform/gotify/secrets.tofu
+++ b/terraform/gotify/secrets.tofu
@@ -24,7 +24,7 @@ resource "onepassword_item" "gotify" {
       field {
         label = "GOTIFY_TOKEN_${upper(replace(replace(section.key, "-", "_"), " ", "_"))}"
         type  = "CONCEALED"
-        value = gotify_application.app[section.key].token
+        value = terraform_data.app_token_cache[section.key].output
       }
     }
   }


### PR DESCRIPTION
## Problem

Since the Gotify server was updated to 3.0.0, `terraform/gotify/secrets.tofu` writes empty `GOTIFY_TOKEN_*` fields into the 1Password `gotify` item.

**Root cause:** Gotify 3.0.0 no longer returns application tokens on `GET /application` — tokens are now only exposed on creation or rotation (`PUT /application/{id}/security`). The `LukasKnuth/gotify` provider (pinned at `0.3.0`, released before Gotify 3.0.0 existed) still reads the token via `GET` on every refresh. That refresh overwrites `gotify_application.app[*].token` in state with an empty string before each `plan`/`apply`, and that empty value then flows straight into the 1Password item.

## Fix

- Added `terraform_data.app_token_cache` in `applications.tofu`, one per app, with `input = gotify_application.app[*].token` and `lifecycle { ignore_changes = [input] }`. This captures the token once (at creation, when it's still populated) and is immune to the provider's empty refresh afterwards.
- `secrets.tofu` now reads `terraform_data.app_token_cache[*].output` instead of `gotify_application.app[*].token` directly.

## ⚠️ Manual step after merge

Existing apps already have an empty token cached in state (inherited from prior refreshes), so this fix alone won't backfill them retroactively. For each affected app, run once:

```sh
tofu apply -replace='gotify_application.app["<Name>"]'
```

This recreates the app in Gotify (new ID + new token), which then gets picked up correctly by the new cache resource on that same apply. Alternatively, rotate the existing app's token via `PUT /application/{id}/security` and manually seed the corresponding `terraform_data` state.

## Upstream

The `LukasKnuth/gotify` provider itself hasn't been updated for the Gotify 3.0 API change (still `0.3.0`, last released Sept 2024). Worth watching/filing an issue upstream; this is a workaround, not a real fix.