### PR TITLE
gotify: add manual override path to seed the token cache

### DIFF
--- a/terraform/gotify/applications.tofu
+++ b/terraform/gotify/applications.tofu
@@ -40,10 +40,19 @@ resource "gotify_application" "app" {
 # ignore all later changes so a refresh can't clobber the cached value.
 # secrets.tofu reads the token from this cache instead of directly from
 # gotify_application.
+#
+# var.app_token_overrides lets a token recovered outside of Terraform (e.g.
+# regenerated in the Gotify UI and re-entered in 1Password) be seeded into
+# the cache once, via the terraform-secret Secret + varsFrom - no local
+# tofu run needed. Once the cache holds a real value, ignore_changes keeps
+# it, so the override key can be cleared from the Secret again afterwards.
 resource "terraform_data" "app_token_cache" {
   for_each = gotify_application.app
 
-  input = each.value.token
+  input = coalesce(
+    lookup(var.app_token_overrides, each.key, null),
+    each.value.token,
+  )
 
   lifecycle {
     ignore_changes = [input]

--- a/terraform/gotify/variables.tofu
+++ b/terraform/gotify/variables.tofu
@@ -7,3 +7,9 @@ variable "OP_CONNECT_TOKEN" {
   sensitive = true
   default   = null
 }
+
+variable "app_token_overrides" {
+  description = "One-time manual overrides for app tokens recovered outside of Terraform (e.g. re-copied from the 1Password item after they were regenerated in the Gotify web UI), keyed by application name. Only needed to seed terraform_data.app_token_cache once after a token was lost to the Gotify 3.0 GET regression. Safe to leave populated afterwards - ignore_changes on the cache means it's only read on the apply where the cache doesn't have a value yet."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Follow-up to the token cache fix

Adds `var.app_token_overrides` (map(string), default {}) so a token recovered outside of Terraform (regenerated in the Gotify UI, re-entered in 1Password by hand) can be seeded into `terraform_data.app_token_cache` once, purely via kubectl, without a local tofu run.

`applications.tofu` now does:
```
input = coalesce(
  lookup(var.app_token_overrides, each.key, null),
  each.value.token,
)
```
so an override wins over the (currently empty) value read from `gotify_application.app[*].token`.

## Why this is needed now

`gotify_application.app[*].token` is already empty in state for all existing apps (wiped by the Gotify 3.0 GET regression before the cache resource existed in this repo). Without an override, the cache would be created empty on its first apply and 1Password would go blank again on the next reconcile.

## Rollout (manual, kubectl only)

1. Merge this PR.
2. Copy the 22 tokens you already re-entered into 1Password back out into a JSON map, e.g. {"Sonarr":"...","CheckMK":"...","Proxmox":"...", ...}
3. Add that JSON (base64-encoded) as `app_token_overrides` in the `terraform-secret` Secret in `flux-system`:
   kubectl -n flux-system get secret terraform-secret -o json > terraform-secret.json
   (edit: add data.app_token_overrides = base64 of the JSON above)
   kubectl -n flux-system apply -f terraform-secret.json
4. Trigger a reconcile so it doesn't wait for the 12h interval:
   kubectl -n flux-system annotate terraform gotify reconcile.fluxcd.io/requestedAt="$(date +%s)" --overwrite
5. approvePlan: auto runs plan+apply automatically. The cache gets seeded with the real tokens, and ignore_changes locks them in from then on.
6. Optional cleanup: clear app_token_overrides back to {} in the Secret afterwards.