### PR TITLE
gotify: add cache_generation to force-replace a stuck token cache

### DIFF
--- a/terraform/gotify/applications.tofu
+++ b/terraform/gotify/applications.tofu
@@ -46,6 +46,13 @@ resource "gotify_application" "app" {
 # the cache once, via the terraform-secret Secret + varsFrom - no local
 # tofu run needed. Once the cache holds a real value, ignore_changes keeps
 # it, so the override key can be cleared from the Secret again afterwards.
+#
+# IMPORTANT: ignore_changes blocks *any* update to `input`, including a
+# fresh app_token_overrides seed, once this resource already exists (e.g.
+# it auto-created with an empty value before an override was ever set).
+# To force a re-seed, bump var.cache_generation - triggers_replace then
+# destroys and recreates the resource, which re-evaluates `input` from
+# scratch since it's a new instance, not an update to the old one.
 resource "terraform_data" "app_token_cache" {
   for_each = gotify_application.app
 
@@ -53,6 +60,8 @@ resource "terraform_data" "app_token_cache" {
     lookup(var.app_token_overrides, each.key, null),
     each.value.token,
   )
+
+  triggers_replace = [var.cache_generation]
 
   lifecycle {
     ignore_changes = [input]

--- a/terraform/gotify/variables.tofu
+++ b/terraform/gotify/variables.tofu
@@ -13,3 +13,9 @@ variable "app_token_overrides" {
   type        = map(string)
   default     = {}
 }
+
+variable "cache_generation" {
+  description = "Bump this (any new distinct string) to force terraform_data.app_token_cache to be destroyed and recreated instead of updated in place. Needed because ignore_changes on the cache's `input` blocks normal updates - including a legitimate app_token_overrides seed - once the cache already holds a (possibly empty) value. A replace re-evaluates `input` fresh, since it's a brand new resource instance. Do not bump this casually: whatever app_token_overrides (or the live Gotify token, which is empty post-3.0) resolves to at the moment of the bump becomes the new permanently-cached value."
+  type        = string
+  default     = "1"
+}


### PR DESCRIPTION
## Problem

The app_token_overrides seed from #7209 had no effect - 1Password still shows empty tokens after applying it.

## Root cause

`terraform_data.app_token_cache` was already auto-created (empty `input`) by an earlier automatic reconcile that ran *before* #7209's override logic was merged - `approvePlan: auto` + a 12h interval means the controller doesn't wait for us. Once a resource exists, `ignore_changes = [input]` blocks *any* future change to that attribute, including a legitimate override - not just the unwanted empty refresh value it was meant to guard against. Terraform planned the update (input: "" -> override value) but silently discarded it per the ignore_changes instruction.

## Fix

Add `var.cache_generation` (default `"1"`) and set `triggers_replace = [var.cache_generation]` on the cache resource. Bumping this variable forces Terraform to destroy and recreate the `terraform_data` instance instead of updating it in place. A brand new resource instance evaluates `input` fresh - `ignore_changes` only suppresses diffs on an *existing* resource, so a replace isn't affected by it.

## Rollout

1. Merge this PR.
2. In the same `terraform-secret` Secret, alongside the still-populated `app_token_overrides`, add a new key `cache_generation` with value `2` (base64-encoded, like `Mgo=` for `2` without a newline - use `echo -n 2 | base64`).
3. Trigger a reconcile:
   ```
   kubectl -n flux-system annotate terraform gotify reconcile.fluxcd.io/requestedAt="$(date +%s)" --overwrite
   ```
4. This time every `terraform_data.app_token_cache[*]` gets destroyed and recreated, picking up the override values for real. 1Password should then show the correct tokens.
5. Afterwards, `app_token_overrides` can be cleared back to `{}` - leave `cache_generation` at `2` (do not revert it back to `1`, that would trigger another replace and re-evaluate `input` with an empty override, wiping the cache again).

Next time this class of issue happens (Gotify upgrade, provider still broken, cache got stuck on a bad value again), the fix is just: put fresh values in `app_token_overrides`, bump `cache_generation` to a new distinct value, reconcile.